### PR TITLE
feat(security): csrf 설정 및 클라이언트 검증 로직 개선 (#21)

### DIFF
--- a/src/main/java/org/ever/_4ever_be_auth/auth/client/filter/ClientValidationFilter.java
+++ b/src/main/java/org/ever/_4ever_be_auth/auth/client/filter/ClientValidationFilter.java
@@ -24,57 +24,38 @@ import java.io.IOException;
 @AllArgsConstructor
 public class ClientValidationFilter extends OncePerRequestFilter {
 
-    private static final String LOGIN_PATH = "/login";
     private static final String AUTHORIZATION_PATH = "/oauth2/authorize";
-    private static final String OAUTH_REQUEST_SESSION_KEY = "OAUTH2_AUTHORIZATION_REQUEST";
 
     private final ClientValidationService clientValidationService;
-    private final RequestCache requestCache = new HttpSessionRequestCache();
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
-                                    FilterChain filterChain
-    ) throws ServletException, IOException {
-        String path = request.getServletPath(); // 요청(request)에 대한 서블릿 경로를 가져옴, ex) /oauth2/authorize
+                                    FilterChain chain)
+            throws ServletException, IOException {
 
-        if (AUTHORIZATION_PATH.equals(path)) {
+        final String path = request.getServletPath();
+        final String method = request.getMethod();
+
+        // ✅ 인가 엔드포인트 GET에서만 전처리 검증
+        if (AUTHORIZATION_PATH.equals(path) && "GET".equalsIgnoreCase(method)) {
             OAuthRequestParams params = extractParams(request);
 
-            log.info("[INFO] OAuth2 인가 요청: 클라이언트 Id={}, 리다이렉트 uri={}, scope={}, state={}",
+            log.info("[INFO] OAuth2 인가 요청: client_id={}, redirect_uri={}, scope={}, state={}",
                     params.clientId(), params.redirectUri(), params.scope(), params.state());
 
-            if (!validateParam(params.clientId(), params.redirectUri(), response)) {
+            try {
+                clientValidationService.validateClient(params.clientId(), params.redirectUri());
+            } catch (ClientValidationException e) {
+                // 표준 방식으로 400만 내려주고 종료 (예외를 던져도 무방)
+                response.sendError(HttpStatus.BAD_REQUEST.value(), e.getMessage());
                 return;
             }
-
-            HttpSession session = request.getSession();
-            session.setAttribute(OAUTH_REQUEST_SESSION_KEY, params);
-            request.setAttribute("oauth2Params", params);
-        } else if (LOGIN_PATH.equals(path)) {
-            SavedRequest savedRequest = requestCache.getRequest(request, response);
-
-            if (savedRequest == null) {
-                response.sendError(HttpStatus.BAD_REQUEST.value(), "직접 접근할 수 없는 경로입니다.");
-                return;
-            }
-
-            HttpSession session = request.getSession(false);
-            if (session == null) {
-                response.sendError(HttpStatus.BAD_REQUEST.value(), "만료된 인가 요청입니다.");
-                return;
-            }
-
-            OAuthRequestParams params =
-                    (OAuthRequestParams) session.getAttribute(OAUTH_REQUEST_SESSION_KEY);
-            if (params == null) {
-                response.sendError(HttpStatus.BAD_REQUEST.value(), "만료된 인가 요청입니다.");
-                return;
-            }
-
-            request.setAttribute("oauth2Params", params);
+            // SavedRequest/세션 저장은 Spring이 처리하므로 여기서 건드리지 않음
         }
-        filterChain.doFilter(request, response);
+
+        // 그 외 모든 경로(/login 포함)는 그대로 통과
+        chain.doFilter(request, response);
     }
 
     private OAuthRequestParams extractParams(HttpServletRequest request) {

--- a/src/main/java/org/ever/_4ever_be_auth/config/CsrfAdvice.java
+++ b/src/main/java/org/ever/_4ever_be_auth/config/CsrfAdvice.java
@@ -1,0 +1,13 @@
+package org.ever._4ever_be_auth.config;
+
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@ControllerAdvice
+public class CsrfAdvice {
+    @ModelAttribute("_csrf")
+    public CsrfToken csrfToken(CsrfToken token) {
+        return token; // 모델에 _csrf 추가
+    }
+}

--- a/src/main/java/org/ever/_4ever_be_auth/config/oauth/AuthorizationServerConfig.java
+++ b/src/main/java/org/ever/_4ever_be_auth/config/oauth/AuthorizationServerConfig.java
@@ -1,7 +1,5 @@
 package org.ever._4ever_be_auth.config.oauth;
 
-import com.nimbusds.jose.jwk.JWKSet;
-import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import org.ever._4ever_be_auth.auth.account.handler.LoginFailureHandler;
@@ -18,20 +16,21 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.OAuth2Token;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
-import org.springframework.security.oauth2.server.authorization.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
 import org.springframework.security.oauth2.server.authorization.config.annotation.web.configurers.OAuth2AuthorizationServerConfigurer;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
@@ -41,21 +40,15 @@ import org.springframework.security.oauth2.server.authorization.token.JwtGenerat
 import org.springframework.security.oauth2.server.authorization.token.OAuth2RefreshTokenGenerator;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenGenerator;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.AuthenticationFailureHandler;
-import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.*;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.*;
 
@@ -76,17 +69,20 @@ public class AuthorizationServerConfig {
     @Order(2)
     public SecurityFilterChain webSecurity(
             HttpSecurity http,
-            ClientValidationFilter clientValidationFilter,
             LoginFailureHandler loginFailureHandler,
             LoginSuccessHandler loginSuccessHandler
     ) throws Exception {
+        var handler = new CsrfTokenRequestAttributeHandler();
         http
                 .securityMatcher("/login", "/error", "/css/**", "/js/**", "/images/**")
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/login", "/error", "/css/**", "/js/**", "/images/**").permitAll()
                         .anyRequest().authenticated()
                 )
-                .csrf(Customizer.withDefaults())
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .csrfTokenRequestHandler(handler)
+                        )
                 .formLogin(form -> form
                         .loginPage("/login")
                         .loginProcessingUrl("/login")
@@ -96,7 +92,6 @@ public class AuthorizationServerConfig {
                         .successHandler(loginSuccessHandler)
                         .permitAll()
                 );
-        http.addFilterBefore(clientValidationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -109,6 +104,7 @@ public class AuthorizationServerConfig {
                 .authorizeHttpRequests(auth -> auth
                         .anyRequest().authenticated()
                 )
+                .csrf(csrf -> csrf.disable())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
         return http.build();
     }
@@ -236,6 +232,18 @@ public class AuthorizationServerConfig {
                         ).permitAll()
                         .anyRequest().authenticated())
                 .csrf(csrf -> csrf.ignoringRequestMatchers(endpointsMatcher))
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .requestCache(c -> c.requestCache(new HttpSessionRequestCache()))
+                .exceptionHandling(e -> e
+                    .defaultAuthenticationEntryPointFor(
+                        new LoginUrlAuthenticationEntryPoint("/login"),
+                        new MediaTypeRequestMatcher(MediaType.TEXT_HTML)
+                    )
+                    .defaultAuthenticationEntryPointFor(
+                        new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED),
+                        new NegatedRequestMatcher(new MediaTypeRequestMatcher(MediaType.TEXT_HTML))
+                    )
+                )
                 .formLogin(form -> form
                         .loginPage("/login")
                         .permitAll());

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -25,7 +25,7 @@
             </div>
 
             <form id="loginForm" method="post" th:action="@{/login}">
-                <input th:name="${_csrf.parameterName}" th:value="${_csrf.token}" type="hidden"/>
+                <input type="hidden" name="_csrf" th:value="${_csrf.token}"/>
 
                 <th:block th:if="${oauth2Params != null}">
                     <input name="client_id" th:value="${oauth2Params.clientId()}" type="hidden"/>


### PR DESCRIPTION
## 요약
- 배포 서버에서 로그인 폼이 CSRF 차단으로 인가 로직 에러 발생함.
- 초기 인가 엔드포인트에서만 차단하도록 수정함.
 
## 관련 이슈
- Closes #21