### PR TITLE
fix(kafka): acknowledgment 기반 수동 커밋 로직 추가 (#47)

### DIFF
--- a/src/main/java/org/ever/_4ever_be_auth/infrastructure/kafka/consumer/AuthUserEventListener.java
+++ b/src/main/java/org/ever/_4ever_be_auth/infrastructure/kafka/consumer/AuthUserEventListener.java
@@ -10,6 +10,7 @@ import org.ever._4ever_be_auth.user.application.port.in.AuthUserSagaPort;
 import org.ever.event.CreateAuthUserEvent;
 import org.ever.event.CreateAuthUserResultEvent;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -26,18 +27,23 @@ public class AuthUserEventListener {
             topics = KafkaTopicConfig.CREATE_USER_TOPIC,
             groupId = "${spring.kafka.consumer.group-id}"
     )
-    public void handleEvent(CreateAuthUserEvent event) {
-        log.info("[KAFKA] CreateAuthUserEvent 수신 - transactionId: {}, userId: {}", event.getTransactionId(), event.getUserId());
+    public void handleEvent(
+            CreateAuthUserEvent event,
+            Acknowledgment acknowledgement
+    ) {
+        log.info("[INFO][KAFKA] CreateAuthUserEvent 수신 - transactionId: {}, userId: {}", event.getTransactionId(), event.getUserId());
 
         String transactionId = event.getTransactionId();
 
         if (transactionId == null || transactionId.isBlank()) {
-            log.error("[KAFKA] 트랜잭션 ID가 없는 이벤트입니다.: {}", event);
+            log.error("[ERROR][KAFKA] 트랜잭션 ID가 없는 이벤트입니다.: {}", event);
+            acknowledgement.acknowledge(); // 수동 커밋
             return;
         }
 
         if (!sagaTransactionStatusService.startProcessing(transactionId)) {
-            log.warn("[KAFKA] 트랜잭션 {} 은 이미 처리된 상태입니다. 이벤트를 무시합니다.", transactionId);
+            log.warn("[WARN][KAFKA] 트랜잭션 {} 은 이미 처리된 상태입니다. 이벤트를 무시합니다.", transactionId);
+            acknowledgement.acknowledge(); // 수동 커밋
             return;
         }
 
@@ -50,9 +56,11 @@ public class AuthUserEventListener {
                         result.getUserId(),
                         result
                 );
-                log.info("[KAFKA] 인증 사용자 생성 완료 이벤트 발행 완료 - transactionId: {}", transactionId);
+                log.info("[INFO][KAFKA] 인증 사용자 생성 완료 이벤트 발행 완료 - transactionId: {}", transactionId);
+                acknowledgement.acknowledge(); // 수동 커밋
             } catch (Exception error) {
-                log.error("[KAFKA] 인증 사용자 생성 처리 실패 - transactionId: {}, cause: {}", transactionId, error.getMessage(), error);
+                log.error("[ERROR][KAFKA] 인증 사용자 생성 처리 실패 - transactionId: {}, cause: {}", transactionId, error.getMessage(), error);
+
                 sagaTransactionStatusService.markFailed(transactionId);
 
                 CreateAuthUserResultEvent failureEvent =
@@ -68,6 +76,7 @@ public class AuthUserEventListener {
                         event.getUserId(),
                         failureEvent
                 );
+                acknowledgement.acknowledge(); // 수동 커밋
             }
             return null;
         });

--- a/src/main/java/org/ever/_4ever_be_auth/infrastructure/kafka/consumer/CustomerUserEventListener.java
+++ b/src/main/java/org/ever/_4ever_be_auth/infrastructure/kafka/consumer/CustomerUserEventListener.java
@@ -10,6 +10,7 @@ import org.ever._4ever_be_auth.user.application.port.in.CustomerUserSagaPort;
 import org.ever.event.CreateAuthUserResultEvent;
 import org.ever.event.CreateCustomerUserEvent;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -26,18 +27,23 @@ public class CustomerUserEventListener {
             topics = KafkaTopicConfig.CREATE_CUSTOMER_USER_TOPIC,
             groupId = "${spring.kafka.consumer.group-id}"
     )
-    public void handleEvent(CreateCustomerUserEvent event) {
-        log.info("[KAFKA][CUSTOMER] CreateCustomerUserEvent 수신 - txId: {}, userId: {}", event.getTransactionId(), event.getUserId());
+    public void handleEvent(
+            CreateCustomerUserEvent event,
+            Acknowledgment acknowledgement
+    ) {
+        log.info("[INFO][KAFKA][CUSTOMER] CreateCustomerUserEvent 수신 - txId: {}, userId: {}", event.getTransactionId(), event.getUserId());
 
         String transactionId = event.getTransactionId();
 
         if (transactionId == null || transactionId.isBlank()) {
-            log.error("[KAFKA][CUSTOMER] 트랜잭션 ID가 없는 이벤트입니다.: {}", event);
+            log.error("[ERROR][KAFKA][CUSTOMER] 트랜잭션 ID가 없는 이벤트입니다.: {}", event);
+            acknowledgement.acknowledge(); // 수동 커밋
             return;
         }
 
         if (!sagaTransactionStatusService.startProcessing(transactionId)) {
-            log.warn("[KAFKA][CUSTOMER] 트랜잭션 {} 은 이미 처리된 상태입니다. 이벤트를 무시합니다.", transactionId);
+            log.warn("[WARN][KAFKA][CUSTOMER] 트랜잭션 {} 은 이미 처리된 상태입니다. 이벤트를 무시합니다.", transactionId);
+            acknowledgement.acknowledge(); // 수동 커밋
             return;
         }
 
@@ -50,9 +56,10 @@ public class CustomerUserEventListener {
                         result.getUserId(),
                         result
                 );
-                log.info("[KAFKA][CUSTOMER] 고객사 사용자 생성 완료 이벤트 발행 - txId: {}", transactionId);
+                log.info("[INFO][KAFKA][CUSTOMER] 고객사 사용자 생성 완료 이벤트 발행 - txId: {}", transactionId);
+                acknowledgement.acknowledge(); // 수동 커밋
             } catch (Exception error) {
-                log.error("[KAFKA][CUSTOMER] 고객사 사용자 생성 처리 실패 - txId: {}, cause: {}", transactionId, error.getMessage(), error);
+                log.error("[ERROR][KAFKA][CUSTOMER] 고객사 사용자 생성 처리 실패 - txId: {}, cause: {}", transactionId, error.getMessage(), error);
                 sagaTransactionStatusService.markFailed(transactionId);
 
                 CreateAuthUserResultEvent failureEvent = CreateAuthUserResultEvent.builder()
@@ -67,6 +74,7 @@ public class CustomerUserEventListener {
                         event.getUserId(),
                         failureEvent
                 );
+                acknowledgement.acknowledge(); // 수동 커밋
             }
             return null;
         });

--- a/src/main/java/org/ever/_4ever_be_auth/infrastructure/kafka/consumer/SupplierUserEventListener.java
+++ b/src/main/java/org/ever/_4ever_be_auth/infrastructure/kafka/consumer/SupplierUserEventListener.java
@@ -10,6 +10,7 @@ import org.ever._4ever_be_auth.user.application.port.in.SupplierUserSagaPort;
 import org.ever.event.CreateAuthUserResultEvent;
 import org.ever.event.CreateSupplierUserEvent;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -26,18 +27,23 @@ public class SupplierUserEventListener {
             topics = KafkaTopicConfig.CREATE_SUPPLIER_USER_TOPIC,
             groupId = "${spring.kafka.consumer.group-id}"
     )
-    public void handleEvent(CreateSupplierUserEvent event) {
-        log.info("[KAFKA][SUPPLIER] CreateSupplierUserEvent 수신 - txId: {}, userId: {}",
+    public void handleEvent(
+            CreateSupplierUserEvent event,
+            Acknowledgment acknowledgement
+    ) {
+        log.info("[INFO][KAFKA][SUPPLIER] CreateSupplierUserEvent 수신 - txId: {}, userId: {}",
                 event.getTransactionId(), event.getUserId());
 
         String transactionId = event.getTransactionId();
         if (transactionId == null || transactionId.isBlank()) {
-            log.error("[KAFKA][SUPPLIER] 트랜잭션 ID가 없는 이벤트입니다.: {}", event);
+            log.error("[ERROR][KAFKA][SUPPLIER] 트랜잭션 ID가 없는 이벤트입니다.: {}", event);
+            acknowledgement.acknowledge(); // 수동 커밋
             return;
         }
 
         if (!sagaTransactionStatusService.startProcessing(transactionId)) {
-            log.warn("[KAFKA][SUPPLIER] 트랜잭션 {} 은 이미 처리된 상태입니다. 이벤트를 무시합니다.", transactionId);
+            log.warn("[WARN][KAFKA][SUPPLIER] 트랜잭션 {} 은 이미 처리된 상태입니다. 이벤트를 무시합니다.", transactionId);
+            acknowledgement.acknowledge(); // 수동 커밋
             return;
         }
 
@@ -50,9 +56,10 @@ public class SupplierUserEventListener {
                         result.getUserId(),
                         result
                 );
-                log.info("[KAFKA][SUPPLIER] 공급사 사용자 생성 완료 이벤트 발행 - txId: {}", transactionId);
+                log.info("[INFO][KAFKA][SUPPLIER] 공급사 사용자 생성 완료 이벤트 발행 - txId: {}", transactionId);
+                acknowledgement.acknowledge(); // 수동 커밋
             } catch (Exception error) {
-                log.error("[KAFKA][SUPPLIER] 공급사 사용자 생성 처리 실패 - txId: {}, cause: {}",
+                log.error("[ERROR][KAFKA][SUPPLIER] 공급사 사용자 생성 처리 실패 - txId: {}, cause: {}",
                         transactionId, error.getMessage(), error);
                 sagaTransactionStatusService.markFailed(transactionId);
 
@@ -68,6 +75,7 @@ public class SupplierUserEventListener {
                         event.getUserId(),
                         failureEvent
                 );
+                acknowledgement.acknowledge(); // 수동 커밋
             }
             return null;
         });


### PR DESCRIPTION
## 요약
- kafka consumer에 acknowledgment 파라미터 추가
- 수신 이벤트 처리 완료 시 acknowledgment 호출
- 이벤트 처리 실패 시에도 수동 커밋 처리 로직 포함
- 로그 메시지 가독성 개선

## 관련 이슈
- Closes #45 